### PR TITLE
Register the outgoing channel

### DIFF
--- a/src/main/java/com/rhetorical/cod/ComWarfare.java
+++ b/src/main/java/com/rhetorical/cod/ComWarfare.java
@@ -135,6 +135,8 @@ public class ComWarfare extends JavaPlugin {
 			return;
 
 		instance = this;
+		
+		getServer().getMessenger().registerOutgoingPluginChannel(this, "BungeeCord");
 
 		getCommand("cod").setExecutor(new CodCommand());
     getCommand("cod").setTabCompleter(new CodTabCompleter());

--- a/src/main/java/com/rhetorical/cod/ComWarfare.java
+++ b/src/main/java/com/rhetorical/cod/ComWarfare.java
@@ -139,7 +139,7 @@ public class ComWarfare extends JavaPlugin {
 		getServer().getMessenger().registerOutgoingPluginChannel(this, "BungeeCord");
 
 		getCommand("cod").setExecutor(new CodCommand());
-    getCommand("cod").setTabCompleter(new CodTabCompleter());
+		getCommand("cod").setTabCompleter(new CodTabCompleter());
 
 		hasQA = Bukkit.getServer().getPluginManager().getPlugin("QualityArmory") != null;
 		hasCS = Bukkit.getServer().getPluginManager().getPlugin("CrackShot") != null;

--- a/src/main/java/com/rhetorical/cod/ComWarfare.java
+++ b/src/main/java/com/rhetorical/cod/ComWarfare.java
@@ -388,7 +388,7 @@ public class ComWarfare extends JavaPlugin {
 	 * @return Returns true if the given command sender has the permission node, the permission node "com.*", or if they're a server operator and aren't in game.
 	 * */
 	public static boolean hasPerm(CommandSender p, String s) {
-		return hasPerm(p, s, true);
+		return hasPerm(p, s, false);
 	}
 
 	/**

--- a/src/main/java/com/rhetorical/cod/ComWarfare.java
+++ b/src/main/java/com/rhetorical/cod/ComWarfare.java
@@ -388,7 +388,7 @@ public class ComWarfare extends JavaPlugin {
 	 * @return Returns true if the given command sender has the permission node, the permission node "com.*", or if they're a server operator and aren't in game.
 	 * */
 	public static boolean hasPerm(CommandSender p, String s) {
-		return hasPerm(p, s, false);
+		return hasPerm(p, s, true);
 	}
 
 	/**


### PR DESCRIPTION
Fixes the bug where players get kicked from the server instead of being sent to the lobby server when serverMode is true and a valid lobbyServer is provided in config.