### PR TITLE
Added skill based matchmaking

### DIFF
--- a/src/main/java/com/rhetorical/cod/Listeners.java
+++ b/src/main/java/com/rhetorical/cod/Listeners.java
@@ -182,6 +182,10 @@ public class Listeners implements Listener {
 			return;
 		}
 
+		if(cause == DamageCause.LAVA || cause == DamageCause.FIRE || cause == DamageCause.FIRE_TICK){
+			p.setFireTicks(0);
+		}
+
 		if (cause != DamageCause.ENTITY_ATTACK && cause != DamageCause.ENTITY_EXPLOSION && cause != DamageCause.PROJECTILE) {
 			boolean exists = true;
 			DamageCause damageCause = null;

--- a/src/main/java/com/rhetorical/cod/game/GameInstance.java
+++ b/src/main/java/com/rhetorical/cod/game/GameInstance.java
@@ -3,6 +3,7 @@ package com.rhetorical.cod.game;
 import com.rhetorical.cod.ComVersion;
 import com.rhetorical.cod.ComWarfare;
 import com.rhetorical.cod.assignments.AssignmentManager;
+import com.rhetorical.cod.files.StatsFile;
 import com.rhetorical.cod.game.events.KillFeedEvent;
 import com.rhetorical.cod.inventories.InventoryManager;
 import com.rhetorical.cod.lang.Lang;
@@ -802,6 +803,79 @@ public class GameInstance implements Listener {
 		}
 	}
 
+	
+	public static boolean isACE(Player p) {
+
+		// Get player stats
+		int kills = 0;
+		int deaths = 0;
+		if (StatsFile.getData().contains(p.getName() + ".kills") && StatsFile.getData().contains(p.getName() + ".deaths")){
+			kills = StatsFile.getData().getInt(p.getName() + ".kills");
+			deaths = StatsFile.getData().getInt(p.getName() + ".deaths");
+		}
+
+		// if deaths is 0 make deaths 1
+		if ( deaths <= 0 ) {
+			deaths = 1;
+		}
+
+		// calculate KD
+		double kd = (double) kills / (double) deaths;
+
+		// calculate
+		if ( kills < 1000 ) {
+			return false;
+		}
+
+		// If you have more than 100 kills and have a KD of 1.2 or higher you are a "good" player
+		return kd >= 1.2 || kills >= 100;
+	}
+
+	public static int getPlayerPowerLevel(Player p) {
+
+		int kills = 0;
+		int deaths = 0;
+		if (StatsFile.getData().contains(p.getName() + ".kills") && StatsFile.getData().contains(p.getName() + ".deaths")){
+			kills = StatsFile.getData().getInt(p.getName() + ".kills");
+			deaths = StatsFile.getData().getInt(p.getName() + ".deaths");
+		}
+
+		// if deaths is 0 make deaths 1
+		if ( deaths <= 0 ) {
+			deaths = 1;
+		}
+
+		// calculate KD
+		double kd = (double) kills / (double) deaths;
+		if ( kills < 100 ) {
+			kd = 0.8;
+		}
+
+		// Calculate power level
+		int powerLevel = (int) (kd * 1000);
+		if(kills <= 5000){
+			powerLevel += kills / 10;
+		}else{
+			powerLevel += 500 + (kills - 5000)/100;
+		}
+
+		return powerLevel;
+	}
+
+	private void addToBlue(Player p){
+		blueTeam.add(p);
+		ChatColor tColor = ChatColor.BLUE;
+		String team = "blue";
+		ComWarfare.sendMessage(p, Lang.ASSIGNED_TO_TEAM.getMessage().replace("{team-color}", tColor + "").replace("{team}", team), ComWarfare.getLang());
+	}
+
+	private void addToRed(Player p){
+		redTeam.add(p);
+		ChatColor tColor = ChatColor.RED;
+		String team = "red";
+		ComWarfare.sendMessage(p, Lang.ASSIGNED_TO_TEAM.getMessage().replace("{team-color}", tColor + "").replace("{team}", team), ComWarfare.getLang());
+	}
+	
 	/**
 	 * Assigns player to teams randomly.
 	 * */

--- a/src/main/java/com/rhetorical/cod/game/GameInstance.java
+++ b/src/main/java/com/rhetorical/cod/game/GameInstance.java
@@ -2701,6 +2701,10 @@ public class GameInstance implements Listener {
 					PerkListener.getInstance().getIsInLastStand().remove(victim);
 					victim.setSneaking(false);
 					victim.setWalkSpeed(0.2f);
+					if (damagers.length < 1) {
+//					ComWarfare.sendMessage(victim, "" + ChatColor.GREEN + ChatColor.BOLD + "YOU " + ChatColor.RESET + "" + ChatColor.WHITE + "[" + Lang.KILLED_TEXT.getMessage() + "] " + ChatColor.RESET + ChatColor.GREEN + ChatColor.BOLD + "YOURSELF", ComWarfare.getLang());
+						kill(victim, victim);
+					}
 					handleDeath(damagers[0], victim);
 				}
 			}

--- a/src/main/java/com/rhetorical/cod/game/GameInstance.java
+++ b/src/main/java/com/rhetorical/cod/game/GameInstance.java
@@ -885,7 +885,7 @@ public class GameInstance implements Listener {
 		sbmm = ComWarfare.getPlugin().getConfig().getBoolean("SkillBasedMatchMaking");
 
 		if (getGamemode() != Gamemode.FFA && getGamemode() != Gamemode.OITC && getGamemode() != Gamemode.GUN && getGamemode() != Gamemode.INFECT) {
-			if(sbmm == true){ // assign teams using skill based matchmaking
+			if(sbmm){ // assign teams using skill based matchmaking
 				for (Player p : players)
 				{
 					if (blueTeam.contains(p) || redTeam.contains(p))

--- a/src/main/java/com/rhetorical/cod/game/GameInstance.java
+++ b/src/main/java/com/rhetorical/cod/game/GameInstance.java
@@ -1510,10 +1510,16 @@ public class GameInstance implements Listener {
 							if (getGamemode() == Gamemode.RESCUE) {
 								if (!(blueTeamScore >= maxScore_RESCUE))
 									startNewRound(7, blueTeam);
+								else{
+									stopGame();
+								}
 							}
 							else if (getGamemode() == Gamemode.GUNFIGHT) {
 								if (!(blueTeamScore >= maxScore_GUNFIGHT))
 									startNewRound(7, blueTeam);
+								else{
+									stopGame();
+								}
 							}
 
 							for (Player pp : players) {
@@ -1529,9 +1535,15 @@ public class GameInstance implements Listener {
 							if (getGamemode() == Gamemode.RESCUE) {
 								if (!(redTeamScore >= maxScore_RESCUE))
 									startNewRound(7, redTeam);
+								else{
+									stopGame();
+								}
 							} else if (getGamemode() == Gamemode.GUNFIGHT) {
 								if (!(redTeamScore >= maxScore_GUNFIGHT))
 									startNewRound(7, redTeam);
+								else{
+									stopGame();
+								}
 							}
 
 							for (Player pp : players) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -190,3 +190,7 @@ RankTiers:
       xp: 200
       credits: 5
     levelCredits: 10
+
+#Skill based matchmaking: In a team based gamemode, joining players will be put on the team that has a lower "power level".
+#"power level" is calculated using the K/D and number of kills by the players on each team.
+SkillBasedMatchMaking: false


### PR DESCRIPTION
SBMM will be disabled by default. Only enabled when SkillBasedMatchMaking: true in config.
SBMM takes into account the  sums of the "power level" of all the players on each team, and puts the player in the team that is deemed to be weaker.
The "power level" is determined by the K/D and total number of kills by a player.